### PR TITLE
iOS13対応

### DIFF
--- a/Sources/PhotoBrowser.swift
+++ b/Sources/PhotoBrowser.swift
@@ -174,6 +174,7 @@ open class PhotoBrowser: UIViewController {
         transitionManager.PhotoBrowser = self
         transitionManager.scrollView = scrollView
         transitioningDelegate = transitionManager
+        modalPresentationStyle = .fullScreen
 
         [scrollView, overlayView, headerView, footerView].forEach { view.addSubview($0) }
         overlayView.addGestureRecognizer(overlayTapGestureRecognizer)


### PR DESCRIPTION
iOS13からmodalPresentationStyleのデフォルトはautomaticとなります。
PhotoTransitionはfullScreenのみ対応しているため、modalPresentationStyleにfullScreenを設定するように修正しました。
